### PR TITLE
fit(CPL2): use HardwareAssertion in CPL2

### DIFF
--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -100,6 +100,7 @@ case class L2Param(
   hartId: Int = 0,
   // Prefetch
   prefetch: Seq[PrefetchParameters] = Nil,
+  blockCircle: Int = 200,
   // L2 Flush
   enableL2Flush: Boolean = false,
   // Performance analysis

--- a/src/main/scala/coupledL2/tl2chi/PrefetchReqBlocker.scala
+++ b/src/main/scala/coupledL2/tl2chi/PrefetchReqBlocker.scala
@@ -17,13 +17,32 @@ object LdState {
   val High      = "b10".U // Greater than 75% full
   val Critical  = "b11".U // Greater than 90% full
 }
-class PrefetchReqBlocker(implicit p: Parameters) extends L2Module with HasCHIOpcodes{
+class PrefetchReqBlocker(implicit p: Parameters) extends L2Module with HasCHIOpcodes {
   val io = IO(new Bundle() {
-    val block = Input(Bool())
+    val shouldBlock = Input(Bool())
     val reqFromPref = Input(new PrefetchReq)
     val reqToSlice = Output(new PrefetchReq)
+    val alreadyBlock = Output(Bool())
   })
+  val blockCircle = cacheParams.blockCircle
+  val counter = RegInit(0.U(log2Ceil(blockCircle).W))
+
+  val needBlock = Wire(Bool())
+  needBlock := io.shouldBlock || (counter =/= 0.U)
+
+  when(io.shouldBlock) {
+    counter := 0.U
+  }
+
+  when(needBlock) {
+    counter := counter + 1.U
+    when(counter === (blockCircle - 1).U) {
+      counter := 0.U
+    }
+  }
+
   val emptyReq = Wire(new PrefetchReq)
   emptyReq := DontCare
-  io.reqToSlice := Mux(io.block, emptyReq, io.reqFromPref)
+  io.reqToSlice := Mux(needBlock, emptyReq, io.reqFromPref)
+  io.alreadyBlock := needBlock
 }

--- a/src/main/scala/coupledL2/tl2chi/RXRSP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXRSP.scala
@@ -52,5 +52,4 @@ class RXRSP(implicit p: Parameters) extends TL2CHIL2Module {
   io.in.respInfo.cBusy.get     := io.out.bits.cBusy
 
   io.out.ready := true.B
-
 }

--- a/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
+++ b/src/main/scala/coupledL2/tl2chi/chi/LinkLayer.scala
@@ -21,6 +21,7 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import coupledL2.L2Module
+import xs.utils.debug.HardwareAssertion
 
 class ChannelIO[+T <: Data](gen: T) extends Bundle {
   // Flit Pending. Early indication that a flit might be transmitted in the following cycle
@@ -138,6 +139,12 @@ class LCredit2Decoupled[T <: Bundle](
     val state = Input(new LinkState())
     val reclaimLCredit = Output(Bool())
   })
+
+  /* ======== HardwareAssertion ======== */
+  val hwaFlags = Array.fill(33)(Wire(Bool()))
+  for (i <- 0 until 33) {
+    hwaFlags(i) := true.B
+  }
 
   require(lcreditNum <= 15)
 

--- a/src/test/scala/top/Top.scala
+++ b/src/test/scala/top/Top.scala
@@ -88,6 +88,7 @@ class Top(implicit p: Parameters) extends LazyModule {
     l2cache.module.io_nodeID := 0.U
     l2cache.module.io.debugTopDown := DontCare
     l2cache.module.io.l2_tlb_req <> DontCare
+    l2cache.module.assertionOut <> DontCare
     dontTouch(l2cache.module.io)
 
     tpMetaSinkNode.foreach(_.in.head._1.ready := true.B)


### PR DESCRIPTION
Replace assert with HardwareAssertion in CPL2. To reduce the number of HardwareAssertion, set new IO(hwaFlag) in MSHR and MMIOBridgeEntry to pass assert flag. 