### PR TITLE
fit(CPL2):replace assert with HAssert

### DIFF
--- a/src/main/scala/coupledL2/CustomL1Hint.scala
+++ b/src/main/scala/coupledL2/CustomL1Hint.scala
@@ -23,6 +23,7 @@ import xs.utils._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.tilelink.TLMessages._
 import coupledL2.utils._
+import xs.utils.debug.HAssert
 
 class HintQueueEntry(implicit p: Parameters) extends L2Bundle {
   val source = UInt(sourceIdBits.W)
@@ -107,8 +108,8 @@ class CustomL1Hint(implicit p: Parameters) extends L2Module {
   hint_s1Queue.io.enq.bits.isKeyword := enqKeyWord_s1
   hint_s1Queue.io.deq.ready := hintQueue.io.enq.ready && !enqValid_s3
   // WARNING:TODO: ensure queue will never overflow
-  assert(hint_s1Queue.io.enq.ready, "hint_s1Queue should never be full")
-  assert(hintQueue.io.enq.ready, "hintQueue should never be full")
+  HAssert(hint_s1Queue.io.enq.ready, "hint_s1Queue should never be full")
+  HAssert(hintQueue.io.enq.ready, "hintQueue should never be full")
 
   hintQueue.io.enq.valid := enqValid_s3 || hint_s1Queue.io.deq.valid
   hintQueue.io.enq.bits.opcode := Mux(enqValid_s3, enqOpcode_s3, hint_s1Queue.io.deq.bits.opcode)
@@ -119,4 +120,5 @@ class CustomL1Hint(implicit p: Parameters) extends L2Module {
   io.l1Hint.valid := hintQueue.io.deq.valid && hintQueue.io.deq.bits.opcode === GrantData
   io.l1Hint.bits.sourceId := hintQueue.io.deq.bits.source
   io.l1Hint.bits.isKeyword := hintQueue.io.deq.bits.isKeyword
+  HAssert.placePipe(1)
 }

--- a/src/main/scala/coupledL2/DataStorage.scala
+++ b/src/main/scala/coupledL2/DataStorage.scala
@@ -22,6 +22,7 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import xs.utils.mbist.MbistPipeline
 import coupledL2.utils.SplittedSRAM
+import xs.utils.debug.HAssert
 
 class DSRequest(implicit p: Parameters) extends L2Bundle {
   val way = UInt(wayBits.W)
@@ -119,12 +120,13 @@ class DataStorage(implicit p: Parameters) extends L2Module {
   io.rdata := dataRead
   io.error := error
 
-  assert(!io.en || !RegNext(io.en, false.B),
+  HAssert(!io.en || !RegNext(io.en, false.B),
     "Continuous SRAM req prohibited under MCP2!")
 
-  assert(!(RegNext(io.en) && (io.req.asUInt =/= RegNext(io.req.asUInt))),
+  HAssert(!(RegNext(io.en) && (io.req.asUInt =/= RegNext(io.req.asUInt))),
     s"DataStorage req fails to hold for 2 cycles!")
 
-  assert(!(RegNext(io.en && io.req.bits.wen) && (io.wdata.asUInt =/= RegNext(io.wdata.asUInt))),
+  HAssert(!(RegNext(io.en && io.req.bits.wen) && (io.wdata.asUInt =/= RegNext(io.wdata.asUInt))),
     s"DataStorage wdata fails to hold for 2 cycles!")
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/GrantBuffer.scala
+++ b/src/main/scala/coupledL2/GrantBuffer.scala
@@ -25,6 +25,7 @@ import freechips.rocketchip.tilelink.TLMessages._
 import coupledL2.prefetch.PrefetchResp
 import xs.utils.perf.{XSPerfAccumulate, XSPerfHistogram, XSPerfMax}
 import xs.utils.tl.MemReqSource
+import xs.utils.debug.HAssert
 
 // record info of those with Grant sent, yet GrantAck not received
 // used to block Probe upwards
@@ -174,7 +175,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
 
   val grantQueueCnt = grantQueue.io.count
   val full = !grantQueue.io.enq.ready
-  assert(!(full && io.d_task.valid), "GrantBuf full and RECEIVE new task, back pressure failed")
+  HAssert(!(full && io.d_task.valid), "GrantBuf full and RECEIVE new task, back pressure failed")
 
   // =========== dequeue entry and fire ===========
   require(beatSize == 2)
@@ -258,7 +259,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
     resp.bits.pfSource := pftRespQueue.get.io.deq.bits.pfSource
     pftRespQueue.get.io.deq.ready := resp.ready
 
-    assert(pftRespQueue.get.io.enq.ready, "pftRespQueue should never be full, no back pressure logic")
+    HAssert(pftRespQueue.get.io.enq.ready, "pftRespQueue should never be full, no back pressure logic")
   }
   // If no prefetch, there never should be HintAck
   // assert(prefetchOpt.nonEmpty.B || !io.d_task.valid || dtaskOpcode =/= HintAck)
@@ -273,7 +274,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
     entry.bits.tag    := io.d_task.bits.task.tag
   }
   val inflight_full = Cat(inflightGrant.map(_.valid)).andR
-  assert(!(inflight_full & (io.d_task.fire && (dtaskOpcode === Grant || dtaskOpcode === GrantData || io.d_task.bits.task.mergeA))), "inflightGrant entries overflow")
+  HAssert(!(inflight_full & (io.d_task.fire && (dtaskOpcode === Grant || dtaskOpcode === GrantData || io.d_task.bits.task.mergeA))), "inflightGrant entries overflow")
 
   // report status to SourceB to block same-addr Probe
   io.grantStatus zip inflightGrant foreach {
@@ -284,7 +285,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
   }
 
   when (io.e.fire) {
-    assert(io.e.bits.sink < grantBufInflightSize.U, "GrantBuf: e.sink overflow inflightGrant size")
+    HAssert(io.e.bits.sink < grantBufInflightSize.U, "GrantBuf: e.sink overflow inflightGrant size")
     inflightGrant(io.e.bits.sink).valid := false.B
   }
 
@@ -333,7 +334,7 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
       case (e, t) =>
         when(e.valid) { t := t + 1.U }
         when(RegNext(e.valid) && !e.valid) { t := 0.U }
-        assert(t < 10000.U, "Inflight Grant Leak")
+        HAssert(t < 10000.U, "Inflight Grant Leak")
 
         val enable = RegNext(e.valid) && !e.valid
         XSPerfHistogram("grant_grantack_period", t, enable, 0, 12, 1)
@@ -343,4 +344,5 @@ class GrantBuffer(implicit p: Parameters) extends L2Module {
     // which can SERIOUSLY affect performance, should consider less drastic prefetch policy
     XSPerfAccumulate("pftRespQueue_about_to_full", noSpaceForMSHRPft.getOrElse(false.B))
   }
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/L2Param.scala
+++ b/src/main/scala/coupledL2/L2Param.scala
@@ -99,7 +99,7 @@ case class L2Param(
   hartId: Int = 0,
   // Prefetch
   prefetch: Seq[PrefetchParameters] = Nil,
-  blockCircle: Int = 200,
+  blockCycle: Int = 200,
   // L2 Flush
   enableL2Flush: Boolean = false,
   // Performance analysis

--- a/src/main/scala/coupledL2/MSHRBuffer.scala
+++ b/src/main/scala/coupledL2/MSHRBuffer.scala
@@ -21,7 +21,7 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import coupledL2.utils._
-import xs.utils.debug.HardwareAssertion
+import xs.utils.debug.HAssert
 class MSHRBufRead(implicit p: Parameters) extends L2Bundle {
   val id = Output(UInt(mshrBits.W))
 }
@@ -49,7 +49,7 @@ class MSHRBuffer(wPorts: Int = 1)(implicit p: Parameters) extends L2Module {
   buffer.zipWithIndex.foreach {
     case (block, i) =>
       val wens = VecInit(io.w.map(w => w.valid && w.bits.id === i.U)).asUInt
-      assert(PopCount(wens) <= 2.U, "triple write to the same MSHR buffer entry")
+      HAssert(PopCount(wens) <= 2.U, "triple write to the same MSHR buffer entry")
 
       val w_data = PriorityMux(wens, io.w.map(_.bits.data))
       val w_beatSel = PriorityMux(wens, io.w.map(_.bits.beatMask))
@@ -63,6 +63,7 @@ class MSHRBuffer(wPorts: Int = 1)(implicit p: Parameters) extends L2Module {
 
   val rdata = buffer(io.r.bits.id).asUInt
   io.resp.data.data := RegEnable(rdata, 0.U.asTypeOf(rdata), io.r.valid)
+  HAssert.placePipe(2)
 }
 
 // may consider just choose an empty entry to insert

--- a/src/main/scala/coupledL2/RequestBuffer.scala
+++ b/src/main/scala/coupledL2/RequestBuffer.scala
@@ -24,6 +24,7 @@ import chisel3._
 import chisel3.util._
 import xs.utils.FastArbiter
 import xs.utils.perf.{XSPerfAccumulate, XSPerfHistogram, XSPerfMax}
+import xs.utils.debug.HAssert
 class ReqEntry(entries: Int = 4)(implicit p: Parameters) extends L2Bundle() {
   val valid    = Bool()
   val rdy      = Bool()
@@ -211,7 +212,7 @@ class RequestBuffer(flow: Boolean = true, entries: Int = 4)(implicit p: Paramete
     entry.waitMS  := conflictMask(in)
 
 //    entry.depMask := depMask
-    assert(PopCount(conflictMaskFromA(in)) <= 2.U)
+    HAssert(PopCount(conflictMaskFromA(in)) <= 2.U)
   }
 
   /* ======== Issue ======== */
@@ -314,7 +315,7 @@ class RequestBuffer(flow: Boolean = true, entries: Int = 4)(implicit p: Paramete
       case (e, t) =>
         when(e.valid) { t := t + 1.U }
         when(RegNext(RegNext(e.valid) && !e.valid)) { t := 0.U }
-        assert(t < 20000.U, "ReqBuf Leak")
+        HAssert(t < 20000.U, "ReqBuf Leak")
 
         val enable = RegNext(e.valid) && !e.valid
         XSPerfHistogram("reqBuf_timer", t, enable, 0, 20, 1, right_strict = true)
@@ -324,4 +325,5 @@ class RequestBuffer(flow: Boolean = true, entries: Int = 4)(implicit p: Paramete
         // assert !(all entries occupied for 100 cycles)
     }
   }
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/SinkA.scala
+++ b/src/main/scala/coupledL2/SinkA.scala
@@ -27,6 +27,7 @@ import coupledL2.prefetch.PrefetchReq
 import xs.utils.common.{AliasKey, PrefetchKey}
 import xs.utils.tl.{MemReqSource, ReqSourceKey}
 import xs.utils.perf.XSPerfAccumulate
+import xs.utils.debug.HAssert
 
 class SinkA(implicit p: Parameters) extends L2Module {
   val io = IO(new Bundle() {
@@ -35,7 +36,7 @@ class SinkA(implicit p: Parameters) extends L2Module {
     val task = DecoupledIO(new TaskBundle)
     val cmoAll = Option.when(cacheParams.enableL2Flush) (new IOCMOAll)
   })
-  assert(!(io.a.valid && (io.a.bits.opcode === PutFullData ||
+  HAssert(!(io.a.valid && (io.a.bits.opcode === PutFullData ||
                           io.a.bits.opcode === PutPartialData)),
     "no Put");
 
@@ -213,4 +214,5 @@ class SinkA(implicit p: Parameters) extends L2Module {
   XSPerfAccumulate("sinkA_put_stall_by_mainpipe", stall &&
     (io.task.bits.opcode === PutFullData || io.task.bits.opcode === PutPartialData))
   prefetchOpt.foreach { _ => XSPerfAccumulate("sinkA_prefetch_stall_by_mainpipe", stall && io.task.bits.opcode === Hint) }
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/SinkC.scala
+++ b/src/main/scala/coupledL2/SinkC.scala
@@ -25,6 +25,7 @@ import org.chipsalliance.cde.config.Parameters
 import xs.utils.RRArbiterInit
 import xs.utils.perf.XSPerfAccumulate
 import xs.utils.tl.MemReqSource
+import xs.utils.debug.HAssert
 
 class PipeBufferResp(implicit p: Parameters) extends L2Bundle {
   val data = Vec(beatSize, UInt((beatBytes * 8).W))
@@ -112,7 +113,7 @@ class SinkC(implicit p: Parameters) extends L2Module {
         dataBuf(nextPtr)(beat) := io.c.bits.data
         beatValids(nextPtr)(beat) := true.B
       }.otherwise {
-        assert(last)
+        HAssert(last)
         dataBuf(nextPtrReg)(beat) := io.c.bits.data
         beatValids(nextPtrReg)(beat) := true.B
       }
@@ -202,4 +203,5 @@ class SinkC(implicit p: Parameters) extends L2Module {
   XSPerfAccumulate("NewDataNestC", io.refillBufWrite.valid)
   //!!WARNING: TODO: if this is zero, that means fucntion [Release-new-data written into refillBuf]
   // is never tested, and may have flaws
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/SourceB.scala
+++ b/src/main/scala/coupledL2/SourceB.scala
@@ -25,6 +25,7 @@ import freechips.rocketchip.tilelink._
 import org.chipsalliance.cde.config.Parameters
 import xs.utils._
 import xs.utils.perf.{XSPerfAccumulate, XSPerfHistogram}
+import xs.utils.debug.HAssert
 
 class GrantStatus(implicit p: Parameters) extends L2Bundle {
   val valid  = Bool()
@@ -90,12 +91,12 @@ class SourceB(implicit p: Parameters) extends L2Module {
   val insertIdx = PriorityEncoder(probes.map(!_.valid))
   val alloc     = !full && io.task.valid
   when(alloc) {
-    val p = probes(insertIdx)
-    p.valid := true.B
-    p.rdy   := !conflict
-    p.waitG := OHToUInt(conflictMask)
-    p.task  := io.task.bits
-    assert(PopCount(conflictMask) <= 1.U)
+    val probeEntry = probes(insertIdx)
+    probeEntry.valid := true.B
+    probeEntry.rdy   := !conflict
+    probeEntry.waitG := OHToUInt(conflictMask)
+    probeEntry.task  := io.task.bits
+    HAssert(PopCount(conflictMask) <= 1.U)
   }
 
   /* ======== Issue ======== */
@@ -127,4 +128,5 @@ class SourceB(implicit p: Parameters) extends L2Module {
     val update = PopCount(probes.map(_.valid)) === i.U
     XSPerfAccumulate(s"probe_buffer_util_$i", update)
   }
+  HAssert.placePipe(1)
 }

--- a/src/main/scala/coupledL2/debug/Monitor.scala
+++ b/src/main/scala/coupledL2/debug/Monitor.scala
@@ -6,6 +6,7 @@ import org.chipsalliance.cde.config.Parameters
 import coupledL2._
 import coupledL2.MetaData._
 import xs.utils.ChiselDB
+import xs.utils.debug.HAssert
 
 class MainpipeMoni(implicit p: Parameters) extends L2Bundle {
   val task_s2 = ValidIO(new TaskBundle())
@@ -59,11 +60,11 @@ class Monitor(implicit p: Parameters) extends L2Module {
 //    "C Release should always hit or have some MSHR meta nested, Tag %x Set %x",
 //    req_s3.tag, req_s3.set)
 
-  assert(RegNext(!(s3_valid && !mshr_req_s3 && dirResult_s3.hit &&
+  HAssert(RegNext(!(s3_valid && !mshr_req_s3 && dirResult_s3.hit &&
     meta_s3.state === TRUNK && !meta_s3.clients.orR)),
     "Trunk should have some client hit")
 
-  assert(RegNext(!(s3_valid && req_s3.fromC && dirResult_s3.hit &&
+  HAssert(RegNext(!(s3_valid && req_s3.fromC && dirResult_s3.hit &&
     !meta_s3.clients.orR)),
     "Invalid Client should not send Release")
 
@@ -101,4 +102,5 @@ class Monitor(implicit p: Parameters) extends L2Module {
 
     table.log(s3Info, s3_valid, s"L2${hartId}_${p(SliceIdKey)}", clock, reset)
   }
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/prefetch/BestOffsetPrefetch.scala
+++ b/src/main/scala/coupledL2/prefetch/BestOffsetPrefetch.scala
@@ -38,6 +38,7 @@ import scopt.Read
 import freechips.rocketchip.util.SeqToAugmentedSeq
 import xs.utils.sram.SRAMTemplate
 import xs.utils.tl.MemReqSource
+import xs.utils.debug.HAssert
 
 case class BOPParameters(
   virtualTrain: Boolean = true,
@@ -189,7 +190,7 @@ class RecentRequestTable(name: String)(implicit p: Parameters) extends BOPModule
   rrTable.io.r.req.bits.setIdx := idx(rAddr)
   rData := rrTable.io.r.resp.data(0)
 
-  assert(!RegNext(io.w.fire && io.r.req.fire), "single port SRAM should not read and write at the same time")
+  HAssert(!RegNext(io.w.fire && io.r.req.fire), "single port SRAM should not read and write at the same time")
 
   /** s0: req handshake */
   val s0_valid = rrTable.io.r.req.fire
@@ -214,6 +215,7 @@ class RecentRequestTable(name: String)(implicit p: Parameters) extends BOPModule
   e.addr := wAddr
   wrrt.log(e, io.w.valid && !io.r.req.valid, site = "RecentRequestTable", clock, reset)
 
+  HAssert.placePipe(2)
 }
 
 class OffsetScoreTable(name: String = "")(implicit p: Parameters) extends BOPModule {

--- a/src/main/scala/coupledL2/prefetch/Prefetcher.scala
+++ b/src/main/scala/coupledL2/prefetch/Prefetcher.scala
@@ -25,6 +25,7 @@ import coupledL2._
 import xs.utils.{ChiselDB, HasCircularQueuePtrHelper, ParallelPriorityMux, Pipeline, RegNextN, ValidIODelay}
 import xs.utils.perf.{XSPerfAccumulate, XSPerfHistogram}
 import xs.utils.tl.MemReqSource
+import xs.utils.debug.HAssert
 
 /* virtual address */
 trait HasPrefetcherHelper extends HasCircularQueuePtrHelper with HasCoupledL2Parameters {
@@ -324,7 +325,7 @@ class Prefetcher(implicit p: Parameters) extends PrefetchModule {
     pfRcv.get.io.tlb_req.resp.valid := false.B
     pfRcv.get.io.tlb_req.resp.bits := DontCare
     pfRcv.get.io.tlb_req.pmp_resp := DontCare
-    assert(!pfRcv.get.io.req.valid ||
+    HAssert(!pfRcv.get.io.req.valid ||
       pfRcv.get.io.req.bits.pfSource === MemReqSource.Prefetch2L2SMS.id.U ||
       pfRcv.get.io.req.bits.pfSource === MemReqSource.Prefetch2L2Stream.id.U ||
       pfRcv.get.io.req.bits.pfSource === MemReqSource.Prefetch2L2Stride.id.U
@@ -426,4 +427,5 @@ class Prefetcher(implicit p: Parameters) extends PrefetchModule {
     site = "L2Prefetch_onlyBOP",
     clock, reset
   )
+  HAssert.placePipe(3)
 }

--- a/src/main/scala/coupledL2/prefetch/TemporalPrefetch.scala
+++ b/src/main/scala/coupledL2/prefetch/TemporalPrefetch.scala
@@ -37,6 +37,7 @@ import coupledL2.utils.ReplacementPolicy
 import xs.utils.common.{TPmetaReq, TPmetaResp}
 import xs.utils.sram.SRAMTemplate
 import xs.utils.tl.MemReqSource
+import xs.utils.debug.HAssert
 
 case class TPParameters(
     tpTableEntries: Int = 16384,
@@ -173,7 +174,7 @@ class TemporalPrefetch(implicit p: Parameters) extends TPModule {
   val enable = io.enable && cstEnable.orR
 
   if (vaddrBitsOpt.isEmpty) {
-    assert(!trainOnVaddr)
+    HAssert(!trainOnVaddr)
   }
 
   /* Stage 0: query tpMetaTable */
@@ -259,7 +260,7 @@ class TemporalPrefetch(implicit p: Parameters) extends TPModule {
 
   tpDataQueue.io.enq.valid := io.tpmeta_port.resp.valid && io.tpmeta_port.resp.bits.hartid === io.hartid
   tpDataQueue.io.enq.bits.rawData := io.tpmeta_port.resp.bits.rawData
-  assert(tpDataQueue.io.enq.ready === true.B) // tpDataQueue is never full
+  HAssert(tpDataQueue.io.enq.ready === true.B) // tpDataQueue is never full
 
 
   /* Recorder logic TODO: compress data based on max delta */
@@ -275,13 +276,13 @@ class TemporalPrefetch(implicit p: Parameters) extends TPModule {
   when(dorecord_s2) {
     recorder_idx := recorder_idx + 1.U
     recorder_data(recorder_idx) := record_data_in >> offsetBits.U // eliminate cacheline offset
-    assert((record_data_in >> offsetBits.U)(fullAddressBits - 1, metaDataLength) === 0.U)
+    HAssert((record_data_in >> offsetBits.U)(fullAddressBits - 1, metaDataLength) === 0.U)
     when(recorder_idx === (recordThres-1.U)) {
       write_record := true.B
       recorder_idx := 0.U
       write_record_trigger := triggerQueue.io.deq.bits
       triggerQueue.io.deq.ready := true.B
-      assert(triggerQueue.io.deq.valid)
+      HAssert(triggerQueue.io.deq.valid)
     }
   }
   when(write_record) {
@@ -289,7 +290,7 @@ class TemporalPrefetch(implicit p: Parameters) extends TPModule {
   }
 
   val tpTable_w_valid = write_record
-  assert(RegNext(s2_valid, false.B) || !tpTable_w_valid, "tpTable_w_valid can only be true in s3")
+  HAssert(RegNext(s2_valid, false.B) || !tpTable_w_valid, "tpTable_w_valid can only be true in s3")
 
   val (write_record_vtag, write_record_vset) = parseVaddr(write_record_trigger.vaddr)
   val (write_record_ptag, write_record_pset) = parsePaddr(write_record_trigger.paddr)
@@ -314,7 +315,7 @@ class TemporalPrefetch(implicit p: Parameters) extends TPModule {
   dataWriteQueue.io.enq.bits.set := tpTable_w_set
   dataWriteQueue.io.enq.bits.way := tpTable_w_way
   dataWriteQueue.io.enq.bits.hartid := io.hartid
-  assert(dataWriteQueue.io.enq.ready === true.B) // TODO: support back-pressure
+  HAssert(dataWriteQueue.io.enq.ready === true.B) // TODO: support back-pressure
 
   when(resetIdx === 0.U) {
     resetFinish := true.B
@@ -395,4 +396,5 @@ class TemporalPrefetch(implicit p: Parameters) extends TPModule {
   triggerDB.log(triggerPt, tpTable_w_valid, "", clock, reset)
   trainDB.log(trainPt, s2_valid, "", clock, reset)
   sendDB.log(sendPt, io.req.fire, "", clock, reset)
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
+++ b/src/main/scala/coupledL2/tl2chi/MMIOBridge.scala
@@ -28,6 +28,7 @@ import coupledL2.HasCoupledL2Parameters
 import coupledL2.{MemBackTypeMM, MemPageTypeNC}
 import xs.utils.{ParallelLookUp, ParallelPriorityMux, RRArbiterInit, SECDEDCode, ZeroExt}
 import xs.utils.perf.XSPerfAccumulate
+import xs.utils.debug.HAssert
 
 class MMIOBridge()(implicit p: Parameters) extends LazyModule
   with HasCoupledL2Parameters
@@ -172,7 +173,7 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
       false.B
     }
     val poison = rxdat.bits.poison.getOrElse(false.B).orR
-    assert(!dataCheck, "UC should not have DataCheck error")
+    HAssert(!dataCheck, "UC should not have DataCheck error")
     denied := denied || nderr
     corrupt := corrupt || derr || nderr || dataCheck || poison
   }
@@ -331,7 +332,9 @@ class MMIOBridgeEntry(edge: TLEdgeIn)(implicit p: Parameters) extends TL2CHIL2Mo
   XSPerfAccumulate("mmio_read_retry", rxrsp.fire && rxrsp.bits.opcode === RetryAck && isRead)
   XSPerfAccumulate("mmio_write_retry", rxrsp.fire && rxrsp.bits.opcode === RetryAck && !isRead)
   XSPerfAccumulate("mmio_read_wait_pcrd", !w_pcrdgrant && isRead)
-  XSPerfAccumulate("mmio_write_wait_pcrd", !w_pcrdgrant && !isRead)  
+  XSPerfAccumulate("mmio_write_wait_pcrd", !w_pcrdgrant && !isRead)
+
+  HAssert.placePipe(2)  
 }
 
 class MMIOBridgeImp(outer: MMIOBridge) extends LazyModuleImp(outer)
@@ -394,9 +397,10 @@ class MMIOBridgeImp(outer: MMIOBridge) extends LazyModuleImp(outer)
     entry.io.chi.rx.dat.ready && io.rx.dat.bits.txnID === i.U
   }).orR
   io.rx.rsp.ready := true.B
-  assert(!io.rx.rsp.valid || Cat(entries.zipWithIndex.map { case (entry, i) =>
+  HAssert(!io.rx.rsp.valid || Cat(entries.zipWithIndex.map { case (entry, i) =>
     entry.io.chi.rx.rsp.ready && io.rx.rsp.bits.txnID === i.U }).orR)
 
+  HAssert.placePipe(3)
   dontTouch(io)
   dontTouch(bus)
 }

--- a/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
+++ b/src/main/scala/coupledL2/tl2chi/MSHRCtl.scala
@@ -28,6 +28,7 @@ import coupledL2._
 import xs.utils.{ParallelMux, ParallelOR, ParallelPriorityMux}
 import xs.utils.perf.{HasPerfEvents, XSPerfAccumulate, XSPerfHistogram, XSPerfMax}
 import xs.utils.tl.MemReqSource
+import xs.utils.debug.HAssert
 
 class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes with HasPerfEvents {
   val io = IO(new Bundle() {
@@ -184,7 +185,7 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
   io.nestedwbDataId.bits := ParallelPriorityMux(mshrs.zipWithIndex.map {
     case (mshr, i) => (mshr.io.nestedwbData, i.U)
   })
-  assert(RegNext(PopCount(mshrs.map(_.io.nestedwbData)) <= 1.U), "should only be one nestedwbData")
+  HAssert(RegNext(PopCount(mshrs.map(_.io.nestedwbData)) <= 1.U), cf"should only be one nestedwbData")
 
 
   /* Status for topDown monitor */
@@ -258,5 +259,6 @@ class MSHRCtl(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes 
     ("l2_cache_long_miss", lmiss.reduce(_ + _))
   )
   generatePerfEvent()
+  HAssert.placePipe(2)
 }
 

--- a/src/main/scala/coupledL2/tl2chi/RXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXDAT.scala
@@ -23,6 +23,7 @@ import org.chipsalliance.cde.config.Parameters
 import coupledL2.{MSHRBufWrite, RespBundle}
 import xs.utils.SECDEDCode
 import xs.utils.debug.HardwareAssertion
+import xs.utils.debug.HAssert
 
 class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
   val io = IO(new Bundle() {
@@ -53,7 +54,7 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
     false.B
   }
   val poison = io.out.bits.poison.getOrElse(false.B).orR
-  assert(!(dataCheck && io.out.valid), "RXDAT(cached) should not have DataCheck error")
+  HAssert(!(dataCheck && io.out.valid), "RXDAT(cached) should not have DataCheck error")
 
   /* Write Refill Buffer*/
   io.refillBufWrite.valid := io.out.valid
@@ -88,4 +89,5 @@ class RXDAT(implicit p: Parameters) extends TL2CHIL2Module {
 
   io.out.ready := true.B
 
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/tl2chi/RXSNP.scala
+++ b/src/main/scala/coupledL2/tl2chi/RXSNP.scala
@@ -26,6 +26,7 @@ import coupledL2.{MSHRInfo, MergeTaskBundle, MetaEntry, TaskBundle}
 import coupledL2.MetaData._
 import xs.utils.ParallelOR
 import xs.utils.tl.MemReqSource
+import xs.utils.debug.HAssert
 
 class RXSNP(
   lCreditNum: Int = 4 // the number of L-Credits that a receiver can provide
@@ -111,7 +112,7 @@ class RXSNP(
     Mux(hit, ms.bits.meta, MetaEntry())
   }})
 
-  assert(!rxsnp.valid || PopCount(replaceNestSnpMask) <= 1.U, "multiple replace nest snoop")
+  HAssert(!rxsnp.valid || PopCount(replaceNestSnpMask) <= 1.U, "multiple replace nest snoop")
 
   task := fromSnpToTaskBundle(rxsnp.bits)
 
@@ -128,11 +129,10 @@ class RXSNP(
   }
 
   val STALL_CNT_MAX = 28000.U
-  assert(stallCnt <= STALL_CNT_MAX,
-    "stallCnt full! maybe there is a deadlock! addr => 0x%x req_opcode => %d txn_id => %d",
-    rxsnp.bits.addr, rxsnp.bits.opcode, rxsnp.bits.txnID)
+  HAssert(stallCnt <= STALL_CNT_MAX,
+    "stallCnt full! maybe there is a deadlock! addr => 0x${rxsnp.bits.addr} req_opcode => 0x${rxsnp.bits.opcode} txn_id => 0x${rxsnp.bits.txnID}")
 
-  assert(!(stall && rxsnp.fire))
+  HAssert(!(stall && rxsnp.fire))
 
   def fromSnpToTaskBundle(snp: CHISNP): TaskBundle = {
     val task = WireInit(0.U.asTypeOf(new TaskBundle))
@@ -188,4 +188,5 @@ class RXSNP(
     task
   }
 
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/tl2chi/Slice.scala
+++ b/src/main/scala/coupledL2/tl2chi/Slice.scala
@@ -23,6 +23,7 @@ import xs.utils.mbist.MbistPipeline
 import org.chipsalliance.cde.config.Parameters
 import coupledL2._
 import coupledL2.prefetch.PrefetchIO
+import xs.utils.debug.HAssert
 
 class OuterBundle(implicit p: Parameters) extends DecoupledPortIO with BaseOuterBundle
 
@@ -220,4 +221,5 @@ class Slice()(implicit p: Parameters) extends BaseSlice[OuterBundle]
   /* ===== Hardware Performance Monitor ===== */
   val perfEvents = Seq(mshrCtl, mainPipe).flatMap(_.getPerfEvents)
   generatePerfEvent()
+  HAssert.placePipe(3)
 }

--- a/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
+++ b/src/main/scala/coupledL2/tl2chi/TL2CHICoupledL2.scala
@@ -24,6 +24,7 @@ import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 import org.chipsalliance.cde.config.Parameters
 import xs.utils.RRArbiterInit
+import xs.utils.debug.HAssert
 abstract class TL2CHIL2Bundle(implicit val p: Parameters) extends Bundle
   with HasCoupledL2Parameters
   with HasCHIMsgParameters
@@ -258,6 +259,8 @@ class TL2CHICoupledL2(implicit p: Parameters) extends CoupledL2Base {
         }
         s.io.prefetch.get.req.valid := Mux(prefBlocker.io.alreadyBlock, false.B, prefetcher.get.io.req.valid && bank_eq(Cat(prefetcher.get.io.req.bits.tag, prefetcher.get.io.req.bits.set), i, bankBits))
     }
+
+    HAssert.placePipe(4)
   }
 
   lazy val module = new CoupledL2Imp(this)

--- a/src/main/scala/coupledL2/tl2chi/TXDAT.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXDAT.scala
@@ -23,6 +23,7 @@ import org.chipsalliance.cde.config.Parameters
 import coupledL2.{DSBeat, DSBlock, TaskBundle, TaskWithData}
 import coupledL2.tl2chi.CHICohStates._
 import xs.utils.{ParallelPriorityMux, SECDEDCode}
+import xs.utils.debug.HAssert
 
 class TXDATBlockBundle(implicit p: Parameters) extends TXBlockBundle {
   val blockSinkBReqEntrance = Bool()
@@ -39,8 +40,8 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     val toReqArb = Output(new TXDATBlockBundle)
   })
 
-  assert(!io.in.valid || io.in.bits.task.toTXDAT, "txChannel is wrong for TXDAT")
-  assert(!io.in.valid || io.in.ready, "TXDAT should never be full")
+  HAssert(!io.in.valid || io.in.bits.task.toTXDAT, "txChannel is wrong for TXDAT")
+  HAssert(!io.in.valid || io.in.ready, "TXDAT should never be full")
   require(chiOpt.isDefined)
   require(beatBytes * 8 == DATA_WIDTH)
 
@@ -71,7 +72,7 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     PopCount(Cat(pipeStatus_s2.map(s => s.valid && Mux(s.bits.mshrTask, s.bits.toTXDAT, s.bits.fromB)))) +
     queueCnt
 
-  assert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXDAT")
+  HAssert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXDAT")
 
   val noSpaceForSinkBReq = inflightCnt >= mshrsAll.U
   val noSpaceForMSHRReq = inflightCnt >= (mshrsAll-2).U
@@ -181,4 +182,5 @@ class TXDAT(implicit p: Parameters) extends TL2CHIL2Module with HasCHIOpcodes {
     dat
   }
 
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/tl2chi/TXREQ.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXREQ.scala
@@ -20,6 +20,7 @@ package coupledL2.tl2chi
 import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
+import xs.utils.debug.HAssert
 
 class TXBlockBundle(implicit p: Parameters) extends TL2CHIL2Bundle {
   // val blockSinkBReqEntrance = Bool()
@@ -40,7 +41,7 @@ class TXREQ(implicit p: Parameters) extends TL2CHIL2Module {
     val sliceId = Input(UInt(bankBits.W))
   })
 
-  assert(!io.pipeReq.valid || io.pipeReq.ready, "TXREQ should always be ready for pipeline req")
+  HAssert(!io.pipeReq.valid || io.pipeReq.ready, "TXREQ should always be ready for pipeline req")
   require(chiOpt.isDefined)
 
   // TODO: an mshrsAll-entry queue is too much, evaluate for a proper size later
@@ -61,7 +62,7 @@ class TXREQ(implicit p: Parameters) extends TL2CHIL2Module {
     1.U - s2ReturnCredit.asUInt + //Fix Timing: always take credit and s2 return if not take 
     queueCnt
 
-  assert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXREQ")
+  HAssert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXREQ")
 
   val noSpace = inflightCnt >= mshrsAll.U
 
@@ -78,4 +79,5 @@ class TXREQ(implicit p: Parameters) extends TL2CHIL2Module {
   io.out.bits.tgtID := SAM(sam).lookup(io.out.bits.addr)
   io.out.bits.size := log2Ceil(blockBytes).U(SIZE_WIDTH.W) // TODO
   io.out.bits.addr := restoreAddressUInt(queue.io.deq.bits.addr, io.sliceId)
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/tl2chi/TXRSP.scala
+++ b/src/main/scala/coupledL2/tl2chi/TXRSP.scala
@@ -21,6 +21,7 @@ import chisel3._
 import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import coupledL2.TaskBundle
+import xs.utils.debug.HAssert
 
 class TXRSPBlockBundle(implicit p: Parameters) extends TXBlockBundle {
   val blockSinkBReqEntrance = Bool()
@@ -39,8 +40,8 @@ class TXRSP(implicit p: Parameters) extends TL2CHIL2Module {
     val toReqArb = Output(new TXRSPBlockBundle)
   })
 
-  assert(!io.pipeRsp.valid || io.pipeRsp.bits.toTXRSP, "txChannel is wrong for TXRSP")
-  assert(io.pipeRsp.ready, "TXRSP should never be full")
+  HAssert(!io.pipeRsp.valid || io.pipeRsp.bits.toTXRSP, "txChannel is wrong for TXRSP")
+  HAssert(io.pipeRsp.ready, "TXRSP should never be full")
   require(chiOpt.isDefined)
 
   // TODO: an mshrsAll-entry queue is too much, evaluate for a proper size later
@@ -59,7 +60,7 @@ class TXRSP(implicit p: Parameters) extends TL2CHIL2Module {
     PopCount(Cat(pipeStatus_s2.map(s => s.valid && Mux(s.bits.mshrTask, s.bits.toTXRSP, s.bits.fromB)))) +
     queueCnt
 
-  assert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXRSP")
+  HAssert(inflightCnt <= mshrsAll.U, "in-flight overflow at TXRSP")
 
   val noSpaceForSinkBReq = inflightCnt >= mshrsAll.U
   val noSpaceForMSHRReq = inflightCnt >= (mshrsAll-2).U
@@ -92,4 +93,5 @@ class TXRSP(implicit p: Parameters) extends TL2CHIL2Module {
     // TODO: Finish this
     rsp
   }
+  HAssert.placePipe(2)
 }

--- a/src/main/scala/coupledL2/utils/Throttle.scala
+++ b/src/main/scala/coupledL2/utils/Throttle.scala
@@ -5,6 +5,7 @@ import chisel3.util._
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
+import xs.utils.debug.HAssert
 
 class Throttle(threshold: Int)(implicit p: Parameters) extends LazyModule {
   val node = TLIdentityNode()
@@ -14,8 +15,8 @@ class Throttle(threshold: Int)(implicit p: Parameters) extends LazyModule {
     val (out, edgeOut) = node.out.head
 
     // TL-UL is guaranteed
-    assert(!in.b.fire && !in.c.fire && !in.e.fire)
-    assert(!out.b.fire && !out.c.fire && !out.e.fire)
+    HAssert(!in.b.fire && !in.c.fire && !in.e.fire)
+    HAssert(!out.b.fire && !out.c.fire && !out.e.fire)
 
     val pendingCnt = RegInit(0.U(32.W))
     val (a_first, _, _, _) = edgeIn.count(in.a)
@@ -30,7 +31,7 @@ class Throttle(threshold: Int)(implicit p: Parameters) extends LazyModule {
         pendingCnt := pendingCnt + 1.U
       }
     }.elsewhen(new_resp) {
-      assert(pendingCnt > 0.U)
+      HAssert(pendingCnt > 0.U)
       pendingCnt := pendingCnt - 1.U
     }
 
@@ -40,6 +41,7 @@ class Throttle(threshold: Int)(implicit p: Parameters) extends LazyModule {
       out.a.valid := false.B
     }
   }
+  HAssert.placePipe(1)
 }
 
 object Throttle {


### PR DESCRIPTION
Replace assert with HAssert method. In class SplittedSRAM, I add (implicit p: Parameters) to deal with the compilation error caused by HAssert. In class SourceB, I change the variable name from p to probeEntry to prevent conflicts caused by implicit parameters. Also correct spelling errors. 